### PR TITLE
chore(deps): bump github/codeql-action from 4.32.4 to 4.35.3

### DIFF
--- a/sca/codeql/action.yml
+++ b/sca/codeql/action.yml
@@ -107,7 +107,7 @@ runs:
   steps:
     # Initialises CodeQL for analysis
     - name: Initialise
-      uses: github/codeql-action/init@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
+      uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
       with:
         languages: ${{ inputs.codeql-languages }}
         queries: +security-extended
@@ -115,11 +115,11 @@ runs:
 
     # Automatically builds compiled languages
     - name: Build
-      uses: github/codeql-action/autobuild@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
+      uses: github/codeql-action/autobuild@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
       continue-on-error: true
 
     # Finalises the CodeQL database, runs the analysis, and uploads the results to Code Scanning
     - name: Analyse
-      uses: github/codeql-action/analyze@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
+      uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
       with:
         upload: ${{ inputs.codeql-upload-findings }}

--- a/sca/owasp/action.yml
+++ b/sca/owasp/action.yml
@@ -125,6 +125,6 @@ runs:
 
     - name: Upload
       if: always()
-      uses: github/codeql-action/upload-sarif@89a39a4e59826350b863aa6b6252a07ad50cf83e # v4.32.4
+      uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
       with:
         sarif_file: ./${{ inputs.output-directory-name }}/dependency-check-report.sarif


### PR DESCRIPTION
# Introduction :pencil2:

Updates github/codeql-action from 4.32.4 to 4.35.3
